### PR TITLE
Remove http from sso_url

### DIFF
--- a/lib/docebo_ruby/user.rb
+++ b/lib/docebo_ruby/user.rb
@@ -28,7 +28,7 @@ module DoceboRuby
       def sso_url(username, options = {})
         timestamp = Time.now.utc.to_i
         token = Digest::MD5.hexdigest([username, timestamp, DoceboRuby.config.sso_token].join(','))
-        "http://#{DoceboRuby.config.saas_url}/doceboLms/index.php?modname=login&op=confirm&login_user=#{username}&time=#{timestamp}&token=#{token}&id_course=#{options[:course]}&destination=#{options[:destination]}"
+        "#{DoceboRuby.config.saas_url}/doceboLms/index.php?modname=login&op=confirm&login_user=#{username}&time=#{timestamp}&token=#{token}&id_course=#{options[:course]}&destination=#{options[:destination]}"
       end
     end
   end


### PR DESCRIPTION
Note: Going forward, we will be passing request protocol as part of SAAS URL.